### PR TITLE
Add support for Qalculate as an optional evaluation backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@ crunch
 
 crunch makes calculations in Vim more accessible by providing an operator to
 evaluate mathematical expressions, loosening Vim's math syntax, and forcing
-integers into floating point numbers.
+integers into floating point numbers. If
+[qalculate](http://qalculate.github.io/) is installed on your system, then
+Crunch can use it to evaluate expressions, offering a much richer syntax (for
+example, currency and unit conversions).
 
 Usage
 -----

--- a/autoload/crunch.vim
+++ b/autoload/crunch.vim
@@ -87,7 +87,7 @@ function! crunch#eval(exprs) abort "{{{2
         if s:crunch_qalc
             let precision = str2nr(g:crunch_precision)
             try
-                let expr_list[i] .= ' = '..trim(system('qalc -terse -set "ignore locale yes" -set "show ending zeroes on" -set "precision '..precision..'" '..shellescape(expr_list[i])))
+                let expr_list[i] .= ' = '..trim(system('qalc -terse -set "precision '..precision..'" '..shellescape(expr_list[i])))
             catch
                 if v:shell_error | call s:echo_error('Qalculate returned error '..v:shell_error..', undoing changes') | undo | endif
                 let expr_list[i] .= ' = '..'Qalculate returned error '..v:shell_error

--- a/doc/crunch.txt
+++ b/doc/crunch.txt
@@ -78,7 +78,13 @@ Or when you enter a floating point number like this:
 A decimal without a leading zero produces an error when you actually wanted
 was this 0.5/2 = 0.25
 
-Crunch solves these trivial problems and many more.
+Crunch solves these trivial problems and many more. If qalculate [0] is
+installed on your system and g:crunch_calc is set, Crunch will use it to
+evaluate expressions, offering a much richer syntax (for example, currency and
+unit conversions). If not, Crunch will use Vim's floating point
+library to evaluate expressions.
+
+[0] http://qalculate.github.io/
 
 
 ==============================================================================
@@ -333,6 +339,23 @@ specifier %g. The Maximum precision depends on the precision of the floating
 point library used when compiling vim, see |floating-point-precision| for
 details. Note that trailing 0s in results are removed.
 
+------------------------------------------------------------------------------
+4.6 g:crunch_calc                                           *crunch-calc*
+
+Default 0
+
+Controls whether or not Crunch uses qalculate to evaluate expressions. If
+qalculate is not installed or g:crunch_calc is set to 0, Crunch will use Vim's
+floating point library to evaluate expressions.
+
+Disabled for backwards compatiblity due to differing Syntaxes for Qalculate
+and Vim. For example to cube 2 in Qalculate, use
+
+    2^3 or 2**3,
+
+whereas Vim expects
+
+    pow(2,3).
 
 ==============================================================================
 5. KNOWN ISSUES                                         *crunch-known-issues*


### PR DESCRIPTION
Previously, Crunch only used Vim's floating point library for evaluations. Now, if Qalculate is installed, Crunch can use it for evaluation of a richer syntax. In particular, the somewhat more natural `2^3` and `2**3` instead of `pow(3,2)`.
Disabled by default for backwards compatibility, though many actually might be missing out.